### PR TITLE
Fixed flag consts to match union order.

### DIFF
--- a/include/emulator/constants.h
+++ b/include/emulator/constants.h
@@ -6,10 +6,10 @@ typedef uint8_t Byte;
 typedef uint16_t Word;
 
 const Word kReset = 0xFFFC;
-const Byte kCarryFlag       = 1;
-const Byte kZeroFlag        = 1 << 1;
-const Byte kInterruptFlag   = 1 << 2;
-const Byte kDecimalFlag     = 1 << 3;
-const Byte kBreakFlag       = 1 << 4;
-const Byte kOverflowFlag    = 1 << 6;
-const Byte kNegativeFlag    = 1 << 7;
+const Byte kCarryFlag = 1 << 7;
+const Byte kZeroFlag = 1 << 6;
+const Byte kInterruptFlag = 1 << 5;
+const Byte kDecimalFlag = 1 << 4;
+const Byte kBreakFlag = 1 << 3;
+const Byte kOverflowFlag = 1 << 1;
+const Byte kNegativeFlag = 1;


### PR DESCRIPTION
Flag consts were backwards in relation to the flags in the defined flag union.  This PR fixes the consts to mimic that order.