### PR TITLE
updated cycle handling, all counts match expected

### DIFF
--- a/test/opcodes_table_ops.cpp
+++ b/test/opcodes_table_ops.cpp
@@ -3891,7 +3891,7 @@ TEST_CASE("OpCodes Table - Ops - JMP - Absolute - jump to new address")
 
     REQUIRE(opcode == 0x4c);
     REQUIRE(cpu.GetProgramCounter() == 0x1234);
-    // REQUIRE(cpu.GetCycleCount() == 3);
+    REQUIRE(cpu.GetCycleCount() == 3);
 }
 
 


### PR DESCRIPTION
I finished implementing proper opcode cycle handling in the rest of my opcodes. The only funky one was JMP which is the only instruction that uses absolute indirect, but all cycles should match the expected values. 
This should wrap up all my opcodes!