### PR TITLE
Updated to pull correct background palette

### DIFF
--- a/include/interface/nes_sdl_video.h
+++ b/include/interface/nes_sdl_video.h
@@ -22,8 +22,8 @@ private:
 
     // const int kScreenWidth = 1024;
     // const int kScreenHeight = 512;
-    const int kScreenWidth = 256;
-    const int kScreenHeight = 240;
+    const int kScreenWidth = 512;
+    const int kScreenHeight = 480;
     SDL_Window *window_ = nullptr;
     SDL_Renderer *renderer_ = nullptr;
     SDL_Texture *texture_ = nullptr;

--- a/src/emulator/nes_ppu_memory_accessor.cpp
+++ b/src/emulator/nes_ppu_memory_accessor.cpp
@@ -86,7 +86,7 @@ void NESPPUMemoryAccessor::WriteMemory(uint16_t location, Byte data, bool suppre
     }
     break;
 
-    // Mirrors of $2000-$2EFF
+    // Palette RAM indexes
     case 0x3f00 ... 0x3f1f:
     {
         memory_[location] = data;

--- a/src/emulator/ppu.cpp
+++ b/src/emulator/ppu.cpp
@@ -209,12 +209,22 @@ void PPU::FillScreenBuffer()
 {
     // Current Nametable
     uint16_t base_nametable = 0x2000;
+    uint16_t base_attribute = 0x23c0;
     if (reg_ctrl_.flags.nametable == 1)
+    {
         base_nametable = 0x2400;
+        base_attribute = 0x27c0;
+    }
     else if (reg_ctrl_.flags.nametable == 2)
+    {
         base_nametable = 0x2800;
+        base_attribute = 0x2bc0;
+    }
     else if (reg_ctrl_.flags.nametable == 3)
+    {
         base_nametable = 0x2c00;
+        base_attribute = 0x2fc0;
+    }
 
     for (int w = 0; w < 32; w++)
     {
@@ -224,6 +234,9 @@ void PPU::FillScreenBuffer()
             Byte nt_tile = ppu_memory_->ReadByte(base_nametable + ((h * 32) + w));
             int16_t nt_index = nt_tile << 4;
 
+            int16_t addr = base_attribute + ((h / 4) * 8) + (w / 4);
+            Byte palette_tile = ppu_memory_->ReadByte(base_attribute + ((h / 4) * 8) + (w / 4));
+            
             // Each tile represents an 8X8 tile of pixels
             for (int p_h = 0; p_h < 8; p_h++)
             {
@@ -233,7 +246,18 @@ void PPU::FillScreenBuffer()
                 for (int p_w = 0; p_w < 8; p_w++)
                 {
                     int base_index = ((h * 32 * (8 * 8)) + (w * 8) + (p_h * 32 * 8) + p_w);
-                    screen_buffer_[base_index] = (((top_byte >> (7 - p_w)) & 0b00000001) << 1) + ((bottom_byte >> (7 - p_w)) & 0b00000001);
+                    
+                    Byte sub_palette = palette_tile;
+                    if((w % 4) >= 2)
+                        sub_palette = sub_palette >> 2;
+
+                    if((h % 4) >= 2)
+                        sub_palette = sub_palette >> 4;
+                        
+                    sub_palette &= 0b00000011;
+                    uint8_t palette_index = ((top_byte >> (7 - p_w)) & 0b00000001) | (((bottom_byte >> (7 - p_w)) & 0b00000001) << 1);
+                    Byte color = ppu_memory_->ReadByte(0x3f00 + (sub_palette * 4) + palette_index);
+                    screen_buffer_[base_index] = color;
                 }
             }
         }

--- a/src/interface/nes_sdl_video.cpp
+++ b/src/interface/nes_sdl_video.cpp
@@ -22,25 +22,23 @@ void NESSDLVideo::RenderFrame()
     auto pixels = ppu_->GetScreenBuffer();
     SDL_Texture *screen_texture = SDL_CreateTexture(renderer_, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STATIC, 256, 240);
 
-    int palette[4] = {0x31, 0x16, 0x0d, 0x37};
     for (int h = 0; h < height; h++)
     {
         for (int w = 0; w < width; w++)
         {
             Byte color = pixels[(h * width) + w];
-
             screen[(h * width * 4) + (w * 4)] = 1;
-            screen[(h * width * 4) + (w * 4) + 1] = kColorMap[(palette[color] * 3) + 2];
-            screen[(h * width * 4) + (w * 4) + 2] = kColorMap[(palette[color] * 3) + 1];
-            screen[(h * width * 4) + (w * 4) + 3] = kColorMap[(palette[color] * 3) + 0];
+            screen[(h * width * 4) + (w * 4) + 1] = kColorMap[(color * 3) + 2];
+            screen[(h * width * 4) + (w * 4) + 2] = kColorMap[(color * 3) + 1];
+            screen[(h * width * 4) + (w * 4) + 3] = kColorMap[(color * 3) + 0];
         }
     }
 
     SDL_Rect table_1_viewport;
     table_1_viewport.x = 0;
     table_1_viewport.y = 0;
-    table_1_viewport.w = 256;
-    table_1_viewport.h = 240;
+    table_1_viewport.w = 512;
+    table_1_viewport.h = 480;
     SDL_RenderSetViewport(renderer_, &table_1_viewport);
     SDL_UpdateTexture(screen_texture, NULL, screen, width * 4);
     SDL_RenderCopy(renderer_, screen_texture, NULL, NULL);


### PR DESCRIPTION
Updated to incorporate palette colors per attribute table.  Doubled size of window.

Sources:
https://wiki.nesdev.org/w/index.php/PPU_attribute_tables
https://wiki.nesdev.org/w/index.php/PPU_memory_map