### PR TITLE
Fix/integrate-controller

### DIFF
--- a/src/interface/keyboard_interface.cpp
+++ b/src/interface/keyboard_interface.cpp
@@ -3,31 +3,51 @@
 
 uint8_t KeyboardInterface::GetInputState() const
 {
+    SDL_Event event;
+    while (SDL_PollEvent(&event))
+    {
+        /* 
+            Poll all events. These will be handled by filters created elsewhere.
+            From https://wiki.libsdl.org/SDL_GetKeyboardState:
+            This function gives you the current state after all events have been processed, 
+            so if a key or button has been pressed and released before you process events, 
+            then the pressed state will never show up in the SDL_GetKeyboardState() calls.
+        */
+    }
+
     // SDL owns this state so we shouldn't free it
     const uint8_t *state = SDL_GetKeyboardState(NULL);
     uint8_t buttonStates = 0;
-    if (state[SDL_SCANCODE_J]) { // A
+    if (state[SDL_SCANCODE_J])
+    { // A
         buttonStates |= 1;
     }
-    if (state[SDL_SCANCODE_K]){ // B
+    if (state[SDL_SCANCODE_K])
+    { // B
         buttonStates |= (1 << 1);
     }
-    if (state[SDL_SCANCODE_SPACE]){ // Select
+    if (state[SDL_SCANCODE_SPACE])
+    { // Select
         buttonStates |= (1 << 2);
     }
-    if (state[SDL_SCANCODE_RETURN]){ // Start
+    if (state[SDL_SCANCODE_RETURN])
+    { // Start
         buttonStates |= (1 << 3);
     }
-    if (state[SDL_SCANCODE_UP] || state[SDL_SCANCODE_W]) { // Up
+    if (state[SDL_SCANCODE_UP] || state[SDL_SCANCODE_W])
+    { // Up
         buttonStates |= (1 << 4);
     }
-    if (state[SDL_SCANCODE_DOWN] || state[SDL_SCANCODE_S]){ // Down
+    if (state[SDL_SCANCODE_DOWN] || state[SDL_SCANCODE_S])
+    { // Down
         buttonStates |= (1 << 5);
     }
-    if (state[SDL_SCANCODE_LEFT] || state[SDL_SCANCODE_A]) { // Left
+    if (state[SDL_SCANCODE_LEFT] || state[SDL_SCANCODE_A])
+    { // Left
         buttonStates |= (1 << 6);
     }
-    if (state[SDL_SCANCODE_RIGHT] || state[SDL_SCANCODE_D]){ // Right
+    if (state[SDL_SCANCODE_RIGHT] || state[SDL_SCANCODE_D])
+    { // Right
         buttonStates |= (1 << 7);
     }
 

--- a/src/interface/nes_main.cpp
+++ b/src/interface/nes_main.cpp
@@ -37,26 +37,21 @@ NESController *controller = nullptr;
 bool request_exit = false;
 bool toggle_logging = false;
 
-static int SDLCALL HandleLogging(void *userdata, SDL_Event *event)
+static int SDLCALL HandleEvents(void *userdata, SDL_Event *event)
 {
     if (event->type == SDL_KEYDOWN && event->key.keysym.sym == SDLK_t)
     {
-        bool *log = (bool *)userdata;
-        *log = !*log;
+        toggle_logging = !toggle_logging;
 
         if (emulator != nullptr)
-            emulator->EnableLogging(*log);
+            emulator->EnableLogging(toggle_logging);
     }
-    return 1; // let all events be added to the queue since we always return 1.
-}
 
-static int SDLCALL HandleExit(void *userdata, SDL_Event *event)
-{
     if (event->type == SDL_QUIT)
     {
-        bool *exit = (bool *)userdata;
-        *exit = true;
+        request_exit = true;
     }
+
     return 1; // let all events be added to the queue since we always return 1.
 }
 
@@ -75,8 +70,7 @@ void RunEmulator()
 #else
 void RunEmulator()
 {
-    SDL_SetEventFilter(HandleExit, &request_exit);
-    SDL_SetEventFilter(HandleLogging, &toggle_logging);
+    SDL_SetEventFilter(HandleEvents, NULL);
     while (!request_exit)
     {
         Uint64 start = SDL_GetPerformanceCounter();

--- a/src/interface/nes_main.cpp
+++ b/src/interface/nes_main.cpp
@@ -39,7 +39,7 @@ bool toggle_logging = false;
 
 static int SDLCALL HandleLogging(void *userdata, SDL_Event *event)
 {
-    if ((event->type == SDL_KEYDOWN || event->type == SDL_KEYUP) && event->key.keysym.sym == SDLK_t)
+    if (event->type == SDL_KEYDOWN && event->key.keysym.sym == SDLK_t)
     {
         bool *log = (bool *)userdata;
         *log = !*log;

--- a/src/interface/nes_main.cpp
+++ b/src/interface/nes_main.cpp
@@ -35,6 +35,20 @@ MemoryAccessorInterface *ppu_memory = nullptr;
 VideoInterface *content_screen = nullptr;
 NESController *controller = nullptr;
 bool request_exit = false;
+bool toggle_logging = false;
+
+static int SDLCALL HandleLogging(void *userdata, SDL_Event *event)
+{
+    if ((event->type == SDL_KEYDOWN || event->type == SDL_KEYUP) && event->key.keysym.sym == SDLK_t)
+    {
+        bool *log = (bool *)userdata;
+        *log = !*log;
+
+        if (emulator != nullptr)
+            emulator->EnableLogging(*log);
+    }
+    return 1; // let all events be added to the queue since we always return 1.
+}
 
 static int SDLCALL HandleExit(void *userdata, SDL_Event *event)
 {
@@ -62,6 +76,7 @@ void RunEmulator()
 void RunEmulator()
 {
     SDL_SetEventFilter(HandleExit, &request_exit);
+    SDL_SetEventFilter(HandleLogging, &toggle_logging);
     while (!request_exit)
     {
         Uint64 start = SDL_GetPerformanceCounter();


### PR DESCRIPTION
Added code to poll all events.  This re-enables our event filters allowing for exit, also incorporated logging toggle.
 
From https://wiki.libsdl.org/SDL_GetKeyboardState:
This function gives you the current state after all events have been processed, so if a key or button has been pressed and released before you process events, then the pressed state will never show up in the SDL_GetKeyboardState() calls.
