### PR TITLE
Feat/opcode-isc

### DIFF
--- a/include/emulator/opcodes_table.h
+++ b/include/emulator/opcodes_table.h
@@ -157,4 +157,6 @@ public:
     void OpSTY(CPU *cpu, Byte opcode);
     template <OpCodesTable::AddressMode A>
     void OpLDY(CPU *cpu, Byte opcode);
+    template <OpCodesTable::AddressMode A>
+    void OpISC(CPU *cpu, Byte opcode);
 };

--- a/src/interface/nes_main.cpp
+++ b/src/interface/nes_main.cpp
@@ -121,12 +121,31 @@ int main(int argc, char **argv)
 
     // Initialize
     cpu_memory = new NESCPUMemoryAccessor();
-    cpu_memory->WriteMemory(0x8000, rom_data + 16, 0x4000);
-    cpu_memory->WriteMemory(0xc000, rom_data + 16, 0x4000);
 
-    ppu_memory = new NESPPUMemoryAccessor();
-    ppu_memory->WriteMemory(0x0000, rom_data + 16 + 16384, 0x2000);
-    delete[] rom_data;
+    if(rom_data[4] == 0x01)
+    {
+        cpu_memory->WriteMemory(0x8000, rom_data + 16, 0x4000);
+        cpu_memory->WriteMemory(0xc000, rom_data + 16, 0x4000);
+        ppu_memory = new NESPPUMemoryAccessor();
+        ppu_memory->WriteMemory(0x0000, rom_data + 16 + 16384, 0x2000);
+        delete[] rom_data;
+    }
+    else if(rom_data[4] == 0x02)
+    {
+        cpu_memory->WriteMemory(0x8000, rom_data + 16, 0x4000);
+        cpu_memory->WriteMemory(0xc000, rom_data + 16 + 0x4000, 0x4000);
+        ppu_memory = new NESPPUMemoryAccessor();
+        ppu_memory->WriteMemory(0x0000, rom_data + 16 + 0x8000, 0x2000);
+        delete[] rom_data;
+    }
+    else
+    {
+        std::cout << "Invalid mapper 0 configuration.\n";
+        delete cpu_memory;
+        cpu_memory = nullptr;
+        delete[] rom_data;
+        return 0;
+    }
 
     controller = new NESController(cpu_memory, new KeyboardInterface());
 

--- a/test/opcodes_table_ops.cpp
+++ b/test/opcodes_table_ops.cpp
@@ -16,7 +16,7 @@ struct ImmediateTestCase
 
 TEST_CASE("OpCodes Table - Ops - Throws Exception on Not Implemented")
 {
-    Byte test_case[] = {0xFF, 0xF0};
+    Byte test_case[] = {0x02, 0xF0};
     Registers registers{.a = 0xAF, .pc = 0x0600};
 
     RawMemoryAccessor memory;
@@ -24,7 +24,7 @@ TEST_CASE("OpCodes Table - Ops - Throws Exception on Not Implemented")
 
     CPU cpu(registers, &memory);
     auto opcode = cpu.GetCurrentOpCode();
-    REQUIRE(opcode == 0xFF);
+    REQUIRE(opcode == 0x02);
 
     cpu.AdvanceProgramCounter();
     OpCodesTable opcodes;


### PR DESCRIPTION
Adds ISC illegal opcode.  Implemented as I was trying to load a 32KB mapper 0 game that was hitting one of these opcodes.  Issue was really related to 32KB games not being loaded correctly.
Enabled fully loading 32KB mapper 0 games. 