### PR TITLE
Misc fixes

### DIFF
--- a/src/emulator/opcodes_table.cpp
+++ b/src/emulator/opcodes_table.cpp
@@ -514,7 +514,8 @@ template <OpCodesTable::AddressMode A>
 void OpCodesTable::OpBRK(CPU *cpu, Byte opcode)
 {
     struct OpCodesTable::AddressingVal address_mode_val = ((*this).*A)(cpu);
-    cpu->SetStatusRegisterFlag(kBreakFlag);
+    StatusRegister copied_sr = cpu->GetStatusRegister();
+    copied_sr.flags.b = 1;
 
     Byte pc_h = (cpu->GetProgramCounter() & 0xFF00) >> 8;
     Byte pc_l = cpu->GetProgramCounter() & 0xFF;
@@ -525,7 +526,7 @@ void OpCodesTable::OpBRK(CPU *cpu, Byte opcode)
     cpu->WriteMemory(0x100 + cpu->GetStackPointer(), pc_l);
     cpu->DecrementStackPointer();
 
-    cpu->WriteMemory(0x100 + cpu->GetStackPointer(), cpu->GetStatusRegister().data);
+    cpu->WriteMemory(0x100 + cpu->GetStackPointer(), copied_sr.data);
     cpu->DecrementStackPointer();
 
     Word new_pc = cpu->GetMemoryWord(0xFFFE);

--- a/test/opcodes_table_ops.cpp
+++ b/test/opcodes_table_ops.cpp
@@ -391,10 +391,13 @@ TEST_CASE("OpCodes Table - Ops - BRK - Implied - Break via interrupt")
     OpCodesTable opcodes;
     opcodes.RunOpCode(&cpu, 0x00);
 
+    StatusRegister copied_sr = cpu.GetStatusRegister();
+    copied_sr.flags.b = 1;
+
     // check stack data
     REQUIRE(cpu.GetMemoryByte(0x1FF) == 0x80);
     REQUIRE(cpu.GetMemoryByte(0x1FE) == 0x20);
-    REQUIRE(cpu.GetMemoryByte(0x1FD) == cpu.GetStatusRegister().data);
+    REQUIRE(cpu.GetMemoryByte(0x1FD) == copied_sr.data);
 
     // sp decremented 3x
     REQUIRE(cpu.GetStackPointer() == 0xff - 3);
@@ -402,7 +405,7 @@ TEST_CASE("OpCodes Table - Ops - BRK - Implied - Break via interrupt")
     // pcl set to 0xFFFE, pch set to 0xFFFF
     REQUIRE(cpu.GetProgramCounter() == 0xEE55);
 
-    REQUIRE(cpu.GetStatusRegister().flags.b == 1);
+    REQUIRE(cpu.GetStatusRegister().flags.b == 0);
 
     // cpu cycle count should increase by 7
     REQUIRE(cpu.GetCycleCount() == 7);


### PR DESCRIPTION
Fixed a couple lingering issues with my code
- changed BRK opcode so that break bit is only set in the copied value that is stored on the stack rather than changing the actual status register
- added a priority check to sprite rendering so that higher priority(i.e. lower OAM index) pixels are not re-drawn. Noticed this was an issue when in DK mario jumps up to grab a hammer, mario hides behind the hammer but it should be the other way around. This helps fix that issue, though it's not perfect. 